### PR TITLE
Fix an error on docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,12 @@ COPY LICENSE /
 COPY README.md /
 COPY CONTRIBUTING.md /
 
-RUN pip install -r ./migration/requirements.txt
+RUN apt -y install python3-venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+RUN python3 -m venv /opt/venv && \
+    . /opt/venv/bin/activate && \
+    pip install -U pip && \
+    pip install -U -r ./migration/requirements.txt
+
+CMD ["source", "/opt/venv/bin/activate"]


### PR DESCRIPTION
The current implementation raise the following error:

```
docker build -t migration .
[+] Building 60.3s (10/10) FINISHED                                                                                                                                                                         docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                                                  0.0s
 => => transferring dockerfile: 779B                                                                                                                                                                                  0.0s
 => [internal] load metadata for docker.io/google/cloud-sdk:slim                                                                                                                                                      2.1s
 => [internal] load .dockerignore                                                                                                                                                                                     0.0s
 => => transferring context: 2B                                                                                                                                                                                       0.0s
 => [1/6] FROM docker.io/google/cloud-sdk:slim@sha256:ba46fd7de33234debe4a5c7021c604e321465fbc3fc9491c54b32ace0688f174                                                                                               55.4s
 => => resolve docker.io/google/cloud-sdk:slim@sha256:ba46fd7de33234debe4a5c7021c604e321465fbc3fc9491c54b32ace0688f174                                                                                                0.0s
 => => sha256:17a49900d4ac9c70ded60e6356a9354d943bf2dbadb731f04d5b08016c7dfe73 18.56MB / 18.56MB                                                                                                                      0.8s
 => => sha256:7a5c5c316488899d686768d1d690e2b87f6a80b7eba316e971bff0cf81b02851 18.57MB / 18.57MB                                                                                                                      0.7s
 => => sha256:ba46fd7de33234debe4a5c7021c604e321465fbc3fc9491c54b32ace0688f174 1.58kB / 1.58kB                                                                                                                        0.0s
 => => sha256:7dc5778a7bcc8e4e34293c928eb8a5fb0fbd8e2aa2c976e2f2668b9944b1feec 4.42kB / 4.42kB                                                                                                                        0.0s
 => => sha256:908b9e25258b60e7ef243b3c0e65e060f3a51d2f44ecd2c13bb0b7ca4d60836f 49.57MB / 49.57MB                                                                                                                      1.1s
 => => sha256:c8c51059a97e410fdef02b55e6a6baf294813c471131952a11c26cdb2cd899ff 3.28kB / 3.28kB                                                                                                                        1.1s
 => => sha256:e23e54e57b62dbb4a47f495f4e32c9c8136840db75a0ca5d912b0df1737729f0 447.52MB / 447.52MB                                                                                                                    9.0s
 => => sha256:81ab1b131f2489cba610c983021afc1b85d41faabc92344539336ae9d70ee205 197B / 197B                                                                                                                            1.5s
 => => extracting sha256:908b9e25258b60e7ef243b3c0e65e060f3a51d2f44ecd2c13bb0b7ca4d60836f                                                                                                                             3.9s
 => => extracting sha256:17a49900d4ac9c70ded60e6356a9354d943bf2dbadb731f04d5b08016c7dfe73                                                                                                                             0.8s
 => => extracting sha256:7a5c5c316488899d686768d1d690e2b87f6a80b7eba316e971bff0cf81b02851                                                                                                                             0.9s
 => => extracting sha256:c8c51059a97e410fdef02b55e6a6baf294813c471131952a11c26cdb2cd899ff                                                                                                                             0.0s
 => => extracting sha256:e23e54e57b62dbb4a47f495f4e32c9c8136840db75a0ca5d912b0df1737729f0                                                                                                                            45.3s
 => => extracting sha256:81ab1b131f2489cba610c983021afc1b85d41faabc92344539336ae9d70ee205                                                                                                                             0.0s
 => [internal] load build context                                                                                                                                                                                     0.0s
 => => transferring context: 103.77kB                                                                                                                                                                                 0.0s
 => [2/6] COPY migration_toolkit /migration                                                                                                                                                                           1.7s
 => [3/6] COPY LICENSE /                                                                                                                                                                                              0.0s
 => [4/6] COPY README.md /                                                                                                                                                                                            0.0s
 => [5/6] COPY CONTRIBUTING.md /                                                                                                                                                                                      0.0s
 => ERROR [6/6] RUN pip install -r ./migration/requirements.txt                                                                                                                                                       0.9s
------                                                                                                                                                                                                                     
 > [6/6] RUN pip install -r ./migration/requirements.txt:                                                                                                                                                                  
0.812 error: externally-managed-environment                                                                                                                                                                                
0.812                                                                                                                                                                                                                      
0.812 × This environment is externally managed                                                                                                                                                                             
0.812 ╰─> To install Python packages system-wide, try apt install
0.812     python3-xyz, where xyz is the package you are trying to
0.812     install.
0.812     
0.812     If you wish to install a non-Debian-packaged Python package,
0.812     create a virtual environment using python3 -m venv path/to/venv.
0.812     Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
0.812     sure you have python3-full installed.
0.812     
0.812     If you wish to install a non-Debian packaged Python application,
0.812     it may be easiest to use pipx install xyz, which will manage a
0.812     virtual environment for you. Make sure you have pipx installed.
0.812     
0.812     See /usr/share/doc/python3.11/README.venv for more information.
0.812 
0.812 note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
0.812 hint: See PEP 668 for the detailed specification.
------
Dockerfile:22
--------------------
  20 |     COPY CONTRIBUTING.md /
  21 |     
  22 | >>> RUN pip install -r ./migration/requirements.txt
--------------------
ERROR: failed to solve: process "/bin/sh -c pip install -r ./migration/requirements.txt" did not complete successfully: exit code: 1
s2@cloudshell:~/datastream-bigquery-migration-toolkit (s2dspgtkgolden-sawfish)$ docker build -t migration .
[+] Building 1.7s (10/10) FINISHED                                                                                                                                                                          docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                                                  0.0s
 => => transferring dockerfile: 779B                                                                                                                                                                                  0.0s
 => [internal] load metadata for docker.io/google/cloud-sdk:slim                                                                                                                                                      0.9s
 => [internal] load .dockerignore                                                                                                                                                                                     0.0s
 => => transferring context: 2B                                                                                                                                                                                       0.0s
 => [internal] load build context                                                                                                                                                                                     0.0s
 => => transferring context: 3.34kB                                                                                                                                                                                   0.0s
 => [1/6] FROM docker.io/google/cloud-sdk:slim@sha256:ba46fd7de33234debe4a5c7021c604e321465fbc3fc9491c54b32ace0688f174                                                                                                0.0s
 => CACHED [2/6] COPY migration_toolkit /migration                                                                                                                                                                    0.0s
 => CACHED [3/6] COPY LICENSE /                                                                                                                                                                                       0.0s
 => CACHED [4/6] COPY README.md /                                                                                                                                                                                     0.0s
 => CACHED [5/6] COPY CONTRIBUTING.md /                                                                                                                                                                               0.0s
 => ERROR [6/6] RUN pip install -r ./migration/requirements.txt                                                                                                                                                       0.7s
------                                                                                                                                                                                                                     
 > [6/6] RUN pip install -r ./migration/requirements.txt:                                                                                                                                                                  
0.585 error: externally-managed-environment                                                                                                                                                                                
0.585                                                                                                                                                                                                                      
0.585 × This environment is externally managed                                                                                                                                                                             
0.585 ╰─> To install Python packages system-wide, try apt install
0.585     python3-xyz, where xyz is the package you are trying to
0.585     install.
0.585     
0.585     If you wish to install a non-Debian-packaged Python package,
0.585     create a virtual environment using python3 -m venv path/to/venv.
0.585     Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
0.585     sure you have python3-full installed.
0.585     
0.585     If you wish to install a non-Debian packaged Python application,
0.585     it may be easiest to use pipx install xyz, which will manage a
0.585     virtual environment for you. Make sure you have pipx installed.
0.585     
0.585     See /usr/share/doc/python3.11/README.venv for more information.
0.585 
0.585 note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
0.585 hint: See PEP 668 for the detailed specification.
------
Dockerfile:22
--------------------
  20 |     COPY CONTRIBUTING.md /
  21 |     
  22 | >>> RUN pip install -r ./migration/requirements.txt
--------------------
ERROR: failed to solve: process "/bin/sh -c pip install -r ./migration/requirements.txt" did not complete successfully: exit code: 1
```

After the patch:

```
...
Downloading urllib3-1.26.16-py2.py3-none-any.whl (143 kB)
Installing collected packages: urllib3, six, pyasn1, protobuf, packaging, idna, grpcio, google-crc32c, charset-normalizer, certifi, cachetools, rsa, requests, python-dateutil, pyasn1-modules, proto-plus, googleapis-common-protos, google-resumable-media, grpcio-status, google-auth, grpc-google-iam-v1, google-api-core, google-cloud-core, google-cloud-datastream, google-cloud-bigquery
Successfully installed cachetools-5.3.1 certifi-2023.7.22 charset-normalizer-3.1.0 google-api-core-2.11.0 google-auth-2.19.1 google-cloud-bigquery-3.11.0 google-cloud-core-2.3.2 google-cloud-datastream-1.7.0 google-crc32c-1.5.0 google-resumable-media-2.5.0 googleapis-common-protos-1.59.0 grpc-google-iam-v1-0.12.6 grpcio-1.54.2 grpcio-status-1.54.2 idna-3.4 packaging-23.1 proto-plus-1.22.2 protobuf-4.23.2 pyasn1-0.5.0 pyasn1-modules-0.3.0 python-dateutil-2.8.2 requests-2.31.0 rsa-4.9 six-1.16.0 urllib3-1.26.16
Removing intermediate container 28eb17bd3c6b
 ---> 55f318ff2639
Step 9/9 : CMD ["source", "/opt/venv/bin/activate"]
 ---> Running in 9c44ba9e98c4
Removing intermediate container 9c44ba9e98c4
 ---> e84d0904c98d
Successfully built e84d0904c98d
Successfully tagged migration:latest
```
